### PR TITLE
Fix python_version format

### DIFF
--- a/nessusscanner.json
+++ b/nessusscanner.json
@@ -14,10 +14,7 @@
     "product_name": "Nessus",
     "product_version_regex": ".*",
     "min_phantom_version": "5.3.5",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "latest_tested_versions": [
         "On-prem, Version 6.8.1"
     ],

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)